### PR TITLE
OAuthRubytter から path に :user を含むメソッドを使うとエラーになる

### DIFF
--- a/lib/rubytter.rb
+++ b/lib/rubytter.rb
@@ -112,6 +112,7 @@ class Rubytter
     if /%s/ =~ path
       eval <<-EOS
         def #{method}(*args)
+          @login = get_login if !login && '#{path}' =~ /:user/ && respond_to?(:get_login, true)
           path = login ? '#{path}'.gsub(':user', login) :'#{path}'
           params = args.last.kind_of?(Hash) ? args.pop : {}
           path = path % args
@@ -122,6 +123,7 @@ class Rubytter
     else
       eval <<-EOS
         def #{method}(params = {})
+          @login = get_login if !login && '#{path}' =~ /:user/ && respond_to?(:get_login, true)
           path = login ? '#{path}'.gsub(':user', login) :'#{path}'
           #{http_method}(path, params)
         end

--- a/lib/rubytter.rb
+++ b/lib/rubytter.rb
@@ -21,6 +21,12 @@ class Rubytter
     end
   end
 
+  class NameUnSetError < StandardError
+    def initialize(method_name)
+      super("first, you must set @login when #{method_name} use")
+    end
+  end
+
   attr_reader :login
   attr_accessor :host, :header, :path_prefix
 
@@ -112,7 +118,7 @@ class Rubytter
     if /%s/ =~ path
       eval <<-EOS
         def #{method}(*args)
-          @login = get_login if !login && '#{path}' =~ /:user/ && respond_to?(:get_login, true)
+          raise NameUnSetError.new(__method__) if !login && '#{path}' =~ /:user/
           path = login ? '#{path}'.gsub(':user', login) :'#{path}'
           params = args.last.kind_of?(Hash) ? args.pop : {}
           path = path % args
@@ -123,7 +129,7 @@ class Rubytter
     else
       eval <<-EOS
         def #{method}(params = {})
-          @login = get_login if !login && '#{path}' =~ /:user/ && respond_to?(:get_login, true)
+          raise NameUnSetError.new(__method__) if !login && '#{path}' =~ /:user/
           path = login ? '#{path}'.gsub(':user', login) :'#{path}'
           #{http_method}(path, params)
         end

--- a/lib/rubytter/oauth_rubytter.rb
+++ b/lib/rubytter/oauth_rubytter.rb
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # must use oauth library.
 class OAuthRubytter < Rubytter
+  attr_accessor :login
+
   # access_token: must be instance of OAuth::AccessToken
   def initialize(access_token, options = {})
     super(nil, nil, options)
@@ -39,12 +41,5 @@ class OAuthRubytter < Rubytter
     else
       raise APIError.new(json_data['error'], res)
     end
-  end
-
-  private
-  def get_login
-    # FIXME
-    # How do I get my screen_name from access_token?
-    user_timeline('').first.user.screen_name
   end
 end

--- a/lib/rubytter/oauth_rubytter.rb
+++ b/lib/rubytter/oauth_rubytter.rb
@@ -40,4 +40,11 @@ class OAuthRubytter < Rubytter
       raise APIError.new(json_data['error'], res)
     end
   end
+
+  private
+  def get_login
+    # FIXME
+    # How do I get my screen_name from access_token?
+    user_timeline('').first.user.screen_name
+  end
 end

--- a/spec/rubytter/oauth_rubytter_spec.rb
+++ b/spec/rubytter/oauth_rubytter_spec.rb
@@ -3,11 +3,11 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 class OAuthRubytter
-  describe "OAuthRubytter" do
+  describe "OAuthRubytter with login" do
     before do
       access_token = Object.new
       @rubytter = OAuthRubytter.new(access_token)
-      @rubytter.stub!(:get_login).and_return('test')
+      @rubytter.login = 'test'
     end
 
     describe 'path include :user' do
@@ -34,6 +34,20 @@ class OAuthRubytter
       it 'should remove member to list' do
         @rubytter.should_receive(:delete).with("/test/foo/members", {:id=>"jugyo"})
         @rubytter.remove_member_from_list('foo', 'jugyo')
+      end
+    end
+  end
+  describe "OAuthRubytter without login" do
+    before do
+      access_token = Object.new
+      @rubytter = OAuthRubytter.new(access_token)
+    end
+
+    describe 'path include :user' do
+      it 'should POST /:user/list to create list' do
+        lambda {
+          @rubytter.create_list('foo')
+        }.should raise_error(NameUnSetError, "first, you must set @login when create_list use")
       end
     end
   end

--- a/spec/rubytter/oauth_rubytter_spec.rb
+++ b/spec/rubytter/oauth_rubytter_spec.rb
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+require File.dirname(__FILE__) + '/../spec_helper'
+
+class OAuthRubytter
+  describe "OAuthRubytter" do
+    before do
+      access_token = Object.new
+      @rubytter = OAuthRubytter.new(access_token)
+      @rubytter.stub!(:get_login).and_return('test')
+    end
+
+    describe 'path include :user' do
+      it 'should POST /:user/list to create list' do
+        @rubytter.should_receive(:post).with("/test/lists", {:name=>"foo"})
+        @rubytter.create_list('foo')
+      end
+
+      it 'should PUT /:user/list to update list' do
+        @rubytter.should_receive(:put).with("/test/lists/foo", {})
+        @rubytter.update_list('foo')
+      end
+
+      it 'should DELETE /:user/list to delete list' do
+        @rubytter.should_receive(:delete).with("/test/lists/foo", {})
+        @rubytter.delete_list('foo')
+      end
+
+      it 'should add member to list' do
+        @rubytter.should_receive(:post).with("/test/foo/members", {:id=>"jugyo"})
+        @rubytter.add_member_to_list('foo', 'jugyo')
+      end
+
+      it 'should remove member to list' do
+        @rubytter.should_receive(:delete).with("/test/foo/members", {:id=>"jugyo"})
+        @rubytter.remove_member_from_list('foo', 'jugyo')
+      end
+    end
+  end
+end


### PR DESCRIPTION
OAuthRubytter の初期化時に login は nil  で行うため，
メソッド実行時に
 path = login ? '#{path}'.gsub(':user', login) :'#{path}'
で :user が置換されず不正なAPIリクエストになってしまいます．

再現するテストと，解決のためのコードを送ります．

login を access_token から取得する方法が良くわからなかったので
そこは適宜修正していただけるとありがたいです．
